### PR TITLE
Propose Change To Submission Naming Convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Conventions
 + Submissions should follow this directory structure
 	
 		Algorithm_Name/Language_Name/username/filename.extension
-		Algorithm_Name/Language_Name/username/filename_unittest.extension
+		Algorithm_Name/Language_Name/username/filename_test.extension
     
 + It is preferred that you prepend or append your files with your Github username or some identifier to avoid overwriting others' implementations. `git blame` is cool, and has many more appropriate applications, but in this context I'd rather pull a flat list of files and be able to check out everyone's contributions that way than have to look through the revisions.
 


### PR DESCRIPTION
I would like you to please consider changing the naming convention for submissions. The change in my pull request will keep file names shorter. It will also allow users of this repo to download just one folder containing all of the files pertinent to a contributor's algorithm implementation.
