### PR TITLE
Updated  the Fisher Yates shuffle to use a passed in Rng

### DIFF
--- a/Fisher-Yates/C#/joshimoo/FisherYates.cs
+++ b/Fisher-Yates/C#/joshimoo/FisherYates.cs
@@ -6,15 +6,22 @@ namespace JamLib.Algorithms.Sorting
     public static class SortingUtils
     {
         // Fisher–Yates_shuffle: http://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
-        public static void Shuffle<T>(this IList<T> array)
+        public static void Shuffle<T>(this IList<T> array) { Shuffle(array, new Random()); }
+        public static void Shuffle<T>(this IList<T> array, Random rng)
         {
-            Random random = new Random();
             for (int i = array.Count; i > 1; i--)
             {
                 // Pick random element to swap. 0 <= j <= i-1
-                int j = random.Next(i);
+                int j = rng.Next(i);
                 Swap(array, i - 1, j);
             }
+        }
+		
+		public static void Swap<T>(IList<T> data, int i, int j)
+        {
+            T temp = data[i];
+            data[i] = data[j];
+            data[j] = temp;
         }
     }
 }

--- a/Fisher-Yates/C#/joshimoo/FisherYatesTests.cs
+++ b/Fisher-Yates/C#/joshimoo/FisherYatesTests.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace JamLib.Algorithms.Sorting.Tests
 {
@@ -9,20 +10,33 @@ namespace JamLib.Algorithms.Sorting.Tests
         public void ShuffleTest()
         {
             int[] actual = new int[] { -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
-            int[] notExpected = new int[] { -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+            int[] expected = new int[] { 8, 10, 5, 1, -1, 6, 9, 3, 0, 4, 2, 7 };
             SortingUtils.Shuffle(actual);
 
-            CollectionAssert.AreNotEqual(notExpected, actual);
+            // Two collections are equivalent if they have the same elements in the same quantity, but in any order.
+            CollectionAssert.AreEquivalent(expected, actual, "The shuffle did not shuffle correctly");
+        }
+
+        [TestMethod()]
+        public void Shuffle_SuppliedRNG_Test()
+        {
+            // using rng with a fixed seed so we can compare this shuffle against a previous shuffle with the same seed.
+            var random = new Random(1024);
+            int[] actual = new int[] { -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+            int[] expected = new int[] { 8, 10, 5, 1, -1, 6, 9, 3, 0, 4, 2, 7 };
+            SortingUtils.Shuffle(actual, random);
+
+            CollectionAssert.AreEqual(expected, actual, "The shuffle did not produce the expected result");
         }
 
         [TestMethod()]
         public void Shuffle_ExtensionMethod_Test()
         {
             int[] actual = new int[] { -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
-            int[] notExpected = new int[] { -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
+            int[] expected = new int[] { -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
             actual.Shuffle();
 
-            CollectionAssert.AreNotEqual(notExpected, actual);
+            CollectionAssert.AreEquivalent(expected, actual);
         }
 
         [TestMethod()]


### PR DESCRIPTION
...the default is the system rng.

Changed Unit tests, to use equivalent testing since the algorithm could produce the same array that was passed in. as mentioned by @jcla1
fixes  kennyledet/Algorithm-Implementations#410
