### PR TITLE
TestFactorial.java

### DIFF
--- a/Factorial/Java/Streamed/Factorial.java
+++ b/Factorial/Java/Streamed/Factorial.java
@@ -1,0 +1,90 @@
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException; 
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+@Warmup(iterations = 5)
+@Measurement(iterations = 10)
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(2)
+public class Factorial {
+
+    @Param({"10", "100", "1000", "10000", "50000", "100000"})
+    private int n;
+
+    public static BigInteger streamedParallel(int n) {
+        if (n < 2) {
+            return BigInteger.valueOf(1);
+        }
+        return IntStream.rangeClosed(2, n).parallel().mapToObj(BigInteger::valueOf).reduce(BigInteger::multiply).get();
+    }
+    
+    public static BigInteger revstreamedParallel(int n) {
+        if (n < 2) {
+            return BigInteger.valueOf(1);
+        }
+        return IntStream.iterate(n, i->i-1).limit(n-1).parallel().mapToObj(BigInteger::valueOf).reduce(BigInteger::multiply).get();
+    }
+   
+    //Tree
+    public static BigInteger ProdTree(int left, int right) {
+        if (left > right) {
+            return BigInteger.ONE;
+        }
+        if (left == right) {
+            return BigInteger.valueOf(left);
+        }
+        if (right - left == 1) {
+            return BigInteger.valueOf(left).multiply(BigInteger.valueOf(right));
+        }
+        int m = (left + right) / 2;
+        return ProdTree(left, m).multiply(ProdTree(m + 1, right));
+    }
+
+    public static BigInteger TreeFactorial(int n) {
+        if (n < 0) {
+            return BigInteger.ZERO;
+        }
+        if (n == 0) {
+            return BigInteger.ONE;
+        }
+        if (n == 1 || n == 2) {
+            return BigInteger.valueOf(n);
+        }
+        return ProdTree(2, n);
+    }
+    
+
+    @Benchmark
+    public void testStreamedParallel(Blackhole bh) {
+        bh.consume(streamedParallel(n));
+    }
+    
+    @Benchmark
+    public void testTreeFactorial(Blackhole bh) {
+        bh.consume(TreeFactorial(n));
+    }
+    
+    
+    
+    public static void main(String[] args) throws RunnerException {
+
+         Options opt = new OptionsBuilder()
+                .include(Factorial.class.getSimpleName())
+                .forks(1)
+                .build();
+
+        new Runner(opt).run();
+    }
+}


### PR DESCRIPTION
streamedParallel vs TreeFactorial 

100_000!

 240,198 ± 17,461 

TreeFactorial
136,608 ±  2,655 

...

Benchmark                          (n)  Mode  Cnt    Score    Error  Units
Factorial.testStreamedParallel      10  avgt   10    0,009 ±  0,001  ms/op
Factorial.testStreamedParallel     100  avgt   10    0,014 ±  0,001  ms/op
Factorial.testStreamedParallel    1000  avgt   10    0,081 ±  0,001  ms/op
Factorial.testStreamedParallel   10000  avgt   10    4,200 ±  0,280  ms/op
Factorial.testStreamedParallel   50000  avgt   10   64,261 ±  2,352  ms/op
Factorial.testStreamedParallel  100000  avgt   10  240,198 ± 17,461  ms/op

...

Benchmark                       (n)  Mode  Cnt    Score    Error  Units
Factorial.testTreeFactorial      10  avgt   10   ≈ 10⁻⁴           ms/op
Factorial.testTreeFactorial     100  avgt   10    0,004 ±  0,001  ms/op
Factorial.testTreeFactorial    1000  avgt   10    0,069 ±  0,001  ms/op
Factorial.testTreeFactorial   10000  avgt   10    3,013 ±  0,025  ms/op
Factorial.testTreeFactorial   50000  avgt   10   44,691 ±  0,529  ms/op
Factorial.testTreeFactorial  100000  avgt   10  136,608 ±  2,655  ms/op
# JMH 1.9.3 (released 109 days ago, please consider updating!)
# VM invoker: /usr/lib/jvm/java-8-oracle/jre/bin/java
# VM options: <none>
# Warmup: 5 iterations, 1 s each
# Measurement: 10 iterations, 1 s each
# Timeout: 10 min per iteration
# Threads: 1 thread, will synchronize iterations
# Benchmark mode: Average time, time/op
# Benchmark: ru.stoloto.isalnikov.benchmarkfactorial.Factorial.testTreeFactorial
# Parameters: (n = 10)
