### PR TITLE
Issue 523

### DIFF
--- a/Boyer_Moore_Horspool/C#/Davipb/Horspool.cs
+++ b/Boyer_Moore_Horspool/C#/Davipb/Horspool.cs
@@ -32,7 +32,7 @@ namespace Horspool
 
 			int index = 0;
 
-			while (index <= haystack.Length - needle.Length)
+			while (index < haystack.Length - needle.Length)
 			{
 				bool match = true;
 
@@ -42,6 +42,10 @@ namespace Horspool
 					{
 						match = false;
 						index += BadMatchTable[haystack[index + needle.Length - 1]];
+						if (index >= haystack.Length)
+                        {
+                            break;
+                        }
 					}
 				}
 


### PR DESCRIPTION
Boyer Moore Horspool String Search walked off end the array in the case where a needle was not in the haystack but it's component characters still existed in the haystuck thus not triggering the initial short circuit